### PR TITLE
Feature/fsar 152 form checkboxes amends

### DIFF
--- a/src/components/form/Checkbox/checkbox.html.twig
+++ b/src/components/form/Checkbox/checkbox.html.twig
@@ -1,11 +1,11 @@
-<fieldset class="checkbox {{ error ? "checkbox--error" : "" }}">
+<fieldset class="checkbox {{ error ? "checkbox--error" : "" }}" aria-describedby="checkbox__description--{{ name }}">
   {% if title is defined %}
     <legend class="checkbox__legend">
       {{ title }}<span class="checkbox__required">{{ required ? "REQUIRED" : "" }}</span>
     </legend>
   {% endif %}
   {% if description is defined %}
-    <p class="checkbox__description">{{ description }}</p>
+    <p class="checkbox__description" id="checkbox__description--{{ name }}">{{ description }}</p>
   {% endif %}
   <div class="checkbox__fields">
     {% for field in fields %}

--- a/src/components/form/Checkbox/checkbox.scss
+++ b/src/components/form/Checkbox/checkbox.scss
@@ -2,14 +2,9 @@
 
 .checkbox {
   border: none;
-  padding: 0 0 0 0.5rem;
-  margin: 1.56rem 0 0 -0.5rem;
+  padding: 0;
+  margin: 1.5rem 0 0 0;
   color: var(--fsa-primary_black);
-
-  @media screen and (min-width: $fsa-md) {
-    margin-left: -1rem;
-    padding-left: 1rem;
-  }
 
   &__legend {
     @include intro;
@@ -47,7 +42,7 @@
     height: 1.5rem;
     border: 1px solid var(--fsa-primary_black);
     position: relative;
-    margin: 0 0.94rem 0 0;
+    margin: 0 1rem 0 0;
     background-color: var(--fsa_tint);
 
     &::-ms-expand {
@@ -71,13 +66,11 @@
 
   &--error {
     border-left: 0.25rem solid var(--fsa-secondary_mid-red);
-    @media screen and (min-width: $fsa-lg) {
-      border-left: 0.23rem solid var(--fsa-secondary_mid-red);
-    }
-
-    margin: 1.56rem 0 0 -0.75rem;
+    margin-left: -0.75rem;
+    padding-left: 0.5rem;
     @media screen and (min-width: $fsa-md) {
-      margin-left: -1.23rem;
+      margin-left: -1.25rem;
+      padding-left: -1rem;
     }
 
     .checkbox__legend {

--- a/src/components/form/Checkbox/checkbox.scss
+++ b/src/components/form/Checkbox/checkbox.scss
@@ -16,7 +16,7 @@
     margin: 0;
     padding: 0;
     font-weight: bold;
-    // Using a float trick here to make the border of fieldset wrap around, not going through, the legend.
+    /* Using a float trick here to make the border of fieldset wrap around, not going through, the legend. */
     float: left;
   }
 

--- a/src/components/form/Checkbox/checkbox.scss
+++ b/src/components/form/Checkbox/checkbox.scss
@@ -7,7 +7,7 @@
   color: var(--fsa-primary_black);
 
   &__legend {
-    @include intro;
+    @include h5;
     margin: 0;
     padding: 0;
     font-weight: bold;
@@ -70,7 +70,7 @@
     padding-left: 0.5rem;
     @media screen and (min-width: $fsa-md) {
       margin-left: -1.25rem;
-      padding-left: -1rem;
+      padding-left: 1rem;
     }
 
     .checkbox__legend {

--- a/src/components/form/Checkbox/checkbox.scss
+++ b/src/components/form/Checkbox/checkbox.scss
@@ -33,7 +33,6 @@
     @include body;
     display: flex;
     align-items: center;
-    align-items: center;
   }
 
   &__input {
@@ -42,8 +41,8 @@
     height: 1.5rem;
     border: 1px solid var(--fsa-primary_black);
     position: relative;
-    margin: 0 1rem 0 0;
     background-color: var(--fsa_tint);
+    margin: 0;
 
     &::-ms-expand {
       display: none;
@@ -62,6 +61,10 @@
       outline: none;
       border: none;
     }
+  }
+
+  &__label {
+    padding: 0 0 0 1rem;
   }
 
   &--error {

--- a/src/components/form/Checkbox/checkbox.scss
+++ b/src/components/form/Checkbox/checkbox.scss
@@ -3,7 +3,7 @@
 .checkbox {
   border: none;
   padding: 0;
-  margin: 1.5rem 0 0 0;
+  margin: 2rem 0 0 0;
   color: var(--fsa-primary_black);
 
   &__legend {

--- a/src/components/forms/ErrorBox/errorBox.scss
+++ b/src/components/forms/ErrorBox/errorBox.scss
@@ -1,9 +1,9 @@
 @import "src/lib.scss";
 
 .error-box {
-  margin: 2rem -0.5rem 0;
+  margin: 2rem -0.75rem 0;
 
-  @media screen and (min-width: $fsa-xs) {
+  @media screen and (min-width: $fsa-md) {
     margin: 2rem -1.25rem 0;
   }
 
@@ -13,9 +13,9 @@
     flex-direction: column;
     align-items: flex-start;
     border: 0.25rem solid var(--fsa-secondary-error-red);
-    padding: 0 0.5rem 1rem;
+    padding: 0 0.5rem 2rem;
 
-    @media screen and (min-width: $fsa-xs) {
+    @media screen and (min-width: $fsa-md) {
       padding: 0 1rem 2rem;
     }
   }


### PR DESCRIPTION
1. Standardise margins for this component and the error box component (per Rachael's request), so that the red error borders align.
2. Add h5 style to title
3. Add aria-describedby to fieldset, so that the description is semantically connected to the fieldset for screenreaders.