### PR TITLE
feature/FSAR-24-document-download-amends

### DIFF
--- a/src/components/general/DocumentDownload/documentDownload.html.twig
+++ b/src/components/general/DocumentDownload/documentDownload.html.twig
@@ -16,7 +16,7 @@
   {% endif %}
   <div class="document-download__content document-download__content--{{ region_is_defined ? "with-region" : "" }}">
     <span class="document-download__format document-download__format--{{ format|lower }}" aria-hidden="true">{{ format|upper }}</span>
-    <div>
+    <div class="document-download__link-wrapper">
       <a href="{{ link }}" class="document-download__link" target="_blank"><span class="visually-hidden">{{ view }} </span>{{ name }}<span class="visually-hidden"> {{ as }} {{ format }}({{ new_window }})</span></a>
       <span class="document-downdload__size">({{ size }})</span>
     </div>

--- a/src/components/general/DocumentDownload/documentDownload.html.twig
+++ b/src/components/general/DocumentDownload/documentDownload.html.twig
@@ -16,11 +16,9 @@
   {% endif %}
   <div class="document-download__content document-download__content--{{ region_is_defined ? "with-region" : "" }}">
     <span class="document-download__format document-download__format--{{ format|lower }}" aria-hidden="true">{{ format|upper }}</span>
-    <a href="{{ link }}" class="document-download__link" target="_blank">
-      <span class="visually-hidden">{{ view }} </span>
-      {{ name }}
-      <span class="visually-hidden"> {{ as }} {{ format }}({{ new_window }})</span>
+    <div>
+      <a href="{{ link }}" class="document-download__link" target="_blank"><span class="visually-hidden">{{ view }} </span>{{ name }}<span class="visually-hidden"> {{ as }} {{ format }}({{ new_window }})</span></a>
       <span class="document-downdload__size">({{ size }})</span>
-    </a>
+    </div>
   </div>
 </section>

--- a/src/components/general/DocumentDownload/documentDownload.scss
+++ b/src/components/general/DocumentDownload/documentDownload.scss
@@ -73,10 +73,9 @@
     }
   }
 
-  &__link {
+  &__link-wrapper {
     margin-left: 0.5rem;
-    text-decoration: underline;
-
+    
     @media screen and (min-width: $fsa-md) {
       margin-left: 1.5rem;
     }
@@ -84,6 +83,10 @@
     @media screen and (min-width: $fsa-lg) {
       margin-left: 1rem;
     }
+  }
+
+  &__link {
+    text-decoration: underline;
 
     &:hover {
       color: var(--fsa__link-green);

--- a/src/components/general/DocumentDownload/documentDownload.stories.js
+++ b/src/components/general/DocumentDownload/documentDownload.stories.js
@@ -1,4 +1,5 @@
 import documentDownload from './documentDownload.html.twig';
+import multipleDocumentDownload from './multipleDocumentDownload.html.twig';
 import './documentDownload.scss';
 
 export default {
@@ -30,3 +31,5 @@ WithMultipleRegions.args = {
   ...WithOneRegion.args,
   region: ['England', 'Wales', 'Northern Ireland'],
 }
+
+export const List = () => multipleDocumentDownload();

--- a/src/components/general/DocumentDownload/multipleDocumentDownload.html.twig
+++ b/src/components/general/DocumentDownload/multipleDocumentDownload.html.twig
@@ -1,0 +1,14 @@
+{% set document_args = {
+    format: 'word',
+    link: '#',
+    view: 'View',
+    name: 'Step by step guide for meat approvals application',
+    as: 'as',
+    new_window: 'Open in a new window',
+    size: '559.42 KB',} 
+  %}
+{% include './documentDownload.html.twig' with document_args %}
+{% include './documentDownload.html.twig' with document_args|merge({ format: 'pdf', region: ['England'] }) %}
+{% include './documentDownload.html.twig' with document_args|merge({ format: 'excel', region: ['Wales'] }) %}
+{% include './documentDownload.html.twig' with document_args|merge({ format: 'pdf', region: ['Northern Ireland'] }) %}
+{% include './documentDownload.html.twig' with document_args|merge({ format: 'word', region: ['England', 'Northern Ireland'] }) %}


### PR DESCRIPTION
1. Move file size out of the anchor tag
2. Create a story that contains a list of download links as Rachael requested. I did not import multipleDocumentDownload.html.twig in documentDownload.js, because the twig file is only used as an example on storybook, and should never be used on the drupal side.