### PR TITLE
Feature/fsar 5 cookie banner amend

### DIFF
--- a/src/components/general/CookieBanner/cookieBanner.scss
+++ b/src/components/general/CookieBanner/cookieBanner.scss
@@ -67,8 +67,7 @@
     margin-top: 1rem;
     @include button(secondary);
     &:hover {
-      background-color: var(--fsa__grey-hover);
-      color: var(--fsa__link-green);
+      background-color: var(--fsa__link-green);
     }
 
     @media screen and (min-width: $fsa-md) {

--- a/src/components/general/CookieBanner/cookieBanner.scss
+++ b/src/components/general/CookieBanner/cookieBanner.scss
@@ -7,14 +7,14 @@
   z-index: 1000;
   width: 100%;
 
-  &--hidden {
-    display: none;
-  }
-
   @media screen and (min-width: $fsa-xl) {
     display: flex;
     justify-content: space-between;
     align-items: center;
+  }
+
+  &--hidden {
+    display: none;
   }
 
   &__message,


### PR DESCRIPTION
Fix `display: flex` overriding `display: none` on fsa-xl viewports