### PR TITLE
Feature/fsar 282 multipage guide pagination

### DIFF
--- a/src/components/general/TemporaryMessage/temporaryMessage.scss
+++ b/src/components/general/TemporaryMessage/temporaryMessage.scss
@@ -20,14 +20,27 @@
     @include grid-cols(4, 4);
   }
 
+  a {
+    @include link;
+    color: var(--fsa-primary_black);
+    text-decoration: none;
+    border-bottom: 1px solid;
+    &:hover:not(:focus-visible) {
+      border-bottom: 4px solid;
+    }
+  }
+
   &--warning {
     background-color: var(--fsa-secondary_mid-yellow);
-    a:focus {
-      color: var(--fsa-primary_white);
-      background-color: var(--fsa-primary_black);
-      border-color: var(--fsa-primary_white);
-      &::after {
-        background-image: url("/src/components/general/ExternalLink/assets/external-white.svg");
+    a {
+      color: var(--fsa-primary_black);
+      &:focus {
+        color: var(--fsa-primary_white);
+        background-color: var(--fsa-primary_black);
+        border-color: var(--fsa-primary_white);
+        &::after {
+          background-image: url("/src/components/general/ExternalLink/assets/external-white.svg");
+        }
       }
     }
   }
@@ -41,10 +54,13 @@
         background-image: url("./assets/warning-white.svg");
       }
 
-      a:focus {
-        color: var(--fsa-primary_black);
-        &::after {
-          background-image: url("/src/components/general/ExternalLink/assets/external-black.svg");
+      a {
+        color: var(--fsa-primary_white);
+        &:focus {
+          color: var(--fsa-primary_black);
+          &::after {
+            background-image: url("/src/components/general/ExternalLink/assets/external-black.svg");
+          }
         }
       }
     }
@@ -69,14 +85,6 @@
       @media screen and (min-width: $fsa-md) {
         margin-left: 0.9rem;
         margin-right: 2rem;
-      }
-    }
-
-    a {
-      text-decoration: none;
-      border-bottom: 1px solid;
-      &:hover:not(:focus-visible) {
-        border-bottom: 4px solid;
       }
     }
 

--- a/src/components/general/TemporaryMessage/temporaryMessage.scss
+++ b/src/components/general/TemporaryMessage/temporaryMessage.scss
@@ -24,9 +24,9 @@
     @include link;
     color: var(--fsa-primary_black);
     text-decoration: none;
-    border-bottom: 1px solid;
+    border-bottom: 1px solid var(--fsa-primary_black);
     &:hover:not(:focus-visible) {
-      border-bottom: 4px solid;
+      border-bottom: 4px solid var(--fsa-primary_black);
     }
   }
 

--- a/src/components/multipageguide/Pagination/assets/left/arrow-focus.svg
+++ b/src/components/multipageguide/Pagination/assets/left/arrow-focus.svg
@@ -1,0 +1,5 @@
+<svg width="28" height="16" viewBox="0 0 28 16" xmlns="http://www.w3.org/2000/svg">
+    <g stroke="#000000" stroke-width="2" fill="none" fill-rule="evenodd" stroke-linecap="round">
+        <path d="M27 8.25H2M9 1 2 8l7 7"/>
+    </g>
+</svg>

--- a/src/components/multipageguide/Pagination/assets/left/arrow-hover.svg
+++ b/src/components/multipageguide/Pagination/assets/left/arrow-hover.svg
@@ -1,0 +1,5 @@
+<svg width="28" height="16" viewBox="0 0 28 16" xmlns="http://www.w3.org/2000/svg">
+    <g stroke="#014B4C" stroke-width="2" fill="none" fill-rule="evenodd" stroke-linecap="round">
+        <path d="M27 8.25H2M9 1 2 8l7 7"/>
+    </g>
+</svg>

--- a/src/components/multipageguide/Pagination/assets/left/arrow.svg
+++ b/src/components/multipageguide/Pagination/assets/left/arrow.svg
@@ -1,0 +1,5 @@
+<svg width="28" height="16" viewBox="0 0 28 16" xmlns="http://www.w3.org/2000/svg">
+    <g stroke="#007C75" stroke-width="2" fill="none" fill-rule="evenodd" stroke-linecap="round">
+        <path d="M27 8.25H2M9 1 2 8l7 7"/>
+    </g>
+</svg>

--- a/src/components/multipageguide/Pagination/assets/right/arrow-focus.svg
+++ b/src/components/multipageguide/Pagination/assets/right/arrow-focus.svg
@@ -1,0 +1,6 @@
+<svg width="28" height="16" viewBox="0 0 28 16" xmlns="http://www.w3.org/2000/svg">
+  <defs></defs>
+  <g stroke="#000000" stroke-width="2" fill="none" fill-rule="evenodd" stroke-linecap="round" transform="matrix(-1, 0, 0, 1, 29, 0)">
+    <path d="M27 8.25H2M9 1 2 8l7 7"></path>
+  </g>
+</svg>

--- a/src/components/multipageguide/Pagination/assets/right/arrow-hover.svg
+++ b/src/components/multipageguide/Pagination/assets/right/arrow-hover.svg
@@ -1,0 +1,6 @@
+<svg width="28" height="16" viewBox="0 0 28 16" xmlns="http://www.w3.org/2000/svg">
+  <defs></defs>
+  <g stroke="#014B4C" stroke-width="2" fill="none" fill-rule="evenodd" stroke-linecap="round" transform="matrix(-1, 0, 0, 1, 29, 0)">
+    <path d="M27 8.25H2M9 1 2 8l7 7"></path>
+  </g>
+</svg>

--- a/src/components/multipageguide/Pagination/assets/right/arrow.svg
+++ b/src/components/multipageguide/Pagination/assets/right/arrow.svg
@@ -1,0 +1,6 @@
+<svg width="28" height="16" viewBox="-0.126 -0.009 28 16" xmlns="http://www.w3.org/2000/svg">
+  <defs></defs>
+  <g stroke="#007C75" stroke-width="2" fill="none" fill-rule="evenodd" stroke-linecap="round" transform="matrix(-1, 0, 0, 1, 29, 0)">
+    <path d="M27 8.25H2M9 1 2 8l7 7"></path>
+  </g>
+</svg>

--- a/src/components/multipageguide/Pagination/pagination.html.twig
+++ b/src/components/multipageguide/Pagination/pagination.html.twig
@@ -1,0 +1,20 @@
+<nav class="multipage-guide-pagination">
+  <ul class="multipage-guide-pagination__list{{ previous is not defined ? ' multipage-guide-pagination__offset' : '' }}">
+    {% if previous %}
+      <li class="multipage-guide-pagination__prev">
+        <a href="#" data-fsa-at="multipage-guide-pagination-previous">
+          <span class="multipage-guide-pagination__label">{{ previous.label }}</span>
+          <p class="multipage-guide-pagination__type">{{ previous.page_name }}</p>
+        </a>
+      </li>
+    {% endif %}
+    {% if next %}
+      <li class="multipage-guide-pagination__next">
+        <a href="#" data-fsa-at="multipage-guide-pagination-next">
+          <span class="multipage-guide-pagination__label">{{ next.label }}</span>
+          <p class="multipage-guide-pagination__type">{{ next.page_name }}</p>
+        </a>
+      </li>
+    {% endif %}
+  </ul>
+</nav>

--- a/src/components/multipageguide/Pagination/pagination.js
+++ b/src/components/multipageguide/Pagination/pagination.js
@@ -1,0 +1,2 @@
+import './pagination.html.twig';
+import './pagination.scss';

--- a/src/components/multipageguide/Pagination/pagination.scss
+++ b/src/components/multipageguide/Pagination/pagination.scss
@@ -44,8 +44,9 @@
     }
   }
   &__offset {
-    justify-content: right;
+    justify-content: flex-end;
   }
+  
   & a {
     @include link;
     text-decoration: none;

--- a/src/components/multipageguide/Pagination/pagination.scss
+++ b/src/components/multipageguide/Pagination/pagination.scss
@@ -1,0 +1,82 @@
+@import "src/lib.scss";
+
+
+@mixin arrow($orientation: left, $child: '.multipage-guide-pagination__label') {
+  $position: ":before";
+  $margin: "right";
+  @if $orientation==right {
+    $position: ":after";
+    $margin: "left";
+  }
+
+  & #{$child}#{$position} {
+    content: "";
+    background-image: url("./assets/#{$orientation}/arrow.svg");
+    display: inline-block;
+    width: 1.75rem;
+    height: 1rem;
+    background-repeat: no-repeat;
+    background-position: center;
+    margin-#{$margin}: 1rem;
+    vertical-align: middle;
+  }
+  &:hover #{$child}#{$position} {
+    background-image: url("./assets/#{$orientation}/arrow-hover.svg");
+    
+  }
+  &:focus #{$child}#{$position} {
+    background-image: url("./assets/#{$orientation}/arrow-focus.svg");
+  }
+}
+
+.multipage-guide-pagination {
+  margin-top: 2rem;
+  border-top: solid 1px var(--fsa__grey-hover);
+  &__list {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    padding: 0;
+    margin: 0;
+    @media screen and (min-width: $fsa-lg) {
+      margin: 2rem 0;
+      flex-direction: row;
+    }
+  }
+  &__offset {
+    justify-content: right;
+  }
+  & a {
+    @include link;
+    text-decoration: none;
+  }
+  &__type {
+    text-decoration: underline;
+  }
+
+  &__prev,
+  &__next {
+    margin-top: 2rem;
+    @media screen and (min-width: $fsa-lg) {
+      margin: 0;
+      width: 50%;
+      flex-basis: 50%;
+      max-width: 50%;
+      //3. Requirements and overview of cooking methods and what if this is a super long title? what will happen? will it fold? will it overflow? who knows? Let's just try it out! :D I don't know if this is long enough but I sure hope so!
+    }
+    a { 
+      display: inline-block;
+    }
+  }
+  &__prev a {
+    @include arrow();
+  }
+  &__next { 
+    a {
+      @include arrow(right);
+    }
+    @media screen and (min-width: $fsa-lg) {
+      text-align: right; 
+    }
+  }
+}

--- a/src/components/multipageguide/Pagination/pagination.scss
+++ b/src/components/multipageguide/Pagination/pagination.scss
@@ -46,7 +46,7 @@
   &__offset {
     justify-content: flex-end;
   }
-  
+
   & a {
     @include link;
     text-decoration: none;
@@ -63,7 +63,6 @@
       width: 50%;
       flex-basis: 50%;
       max-width: 50%;
-      //3. Requirements and overview of cooking methods and what if this is a super long title? what will happen? will it fold? will it overflow? who knows? Let's just try it out! :D I don't know if this is long enough but I sure hope so!
     }
     a { 
       display: inline-block;

--- a/src/components/multipageguide/Pagination/pagination.stories.js
+++ b/src/components/multipageguide/Pagination/pagination.stories.js
@@ -1,0 +1,36 @@
+import pagination from './pagination.html.twig';
+import './pagination.scss';
+
+export default {
+  title: 'Components/Multipage Guide/Pagination',
+};
+
+const Template = (args) => pagination(args);
+
+export const PaginationStart = Template.bind({});
+PaginationStart.args = {
+  next: {
+    label: "Next",
+    page_name: "2. Introduction"
+  }
+};
+
+export const PaginationMid = Template.bind({});
+PaginationMid.args = {
+  previous: {
+    label: "Previous",
+    page_name: "1. Guidance summary"
+  },
+  next: {
+    label: "Next",
+    page_name: "3. Requirements and overview of cooking methods"
+  }
+};
+
+export const PaginationEnd = Template.bind({});
+PaginationEnd.args = {
+  previous: {
+    label: "Previous",
+    page_name: "2. Introduction"
+  }
+};

--- a/src/index.js
+++ b/src/index.js
@@ -72,6 +72,9 @@ import backToTop from './components/article/BackToTop/backToTop';
 import pdfAndPrintButtons from './components/article/PdfAndPrintButtons/pdfAndPrintButtons';
 import stickySidebar from './components/article/StickySidebar/stickySidebar';
 
+/* Multipage guide Components */
+import './components/multipageguide/Pagination/pagination';
+
 /* Layout Components */
 import './layout/formLayout/formLayout';
 import './layout/twoColumn/twoColumn';

--- a/src/pages/multipageguide/multipageguide.html.twig
+++ b/src/pages/multipageguide/multipageguide.html.twig
@@ -1,0 +1,102 @@
+
+{% extends '../../layout/contentLayout/contentLayout.html.twig' %}
+{% set breadcrumb_items = [
+  {
+    'text': 'Home',
+    'url': '/'
+  },
+  {
+    'text': 'Business guidance',
+    'url': '/business-guidance'
+  },
+  {
+    'text': 'Introduction',
+    'url': null
+  },
+] %}
+{% block header %}
+  {% include '../../components/general/Breadcrumb/breadcrumbs.html.twig' with {
+    items: breadcrumb_items,
+    expanded: false,
+  } %}
+{% endblock %}
+{% block top %}
+{# Add Multipage guide ArticleHero variant #}
+{% endblock %}
+{% block left %}
+  {% include '@components/components/article/StickySidebar/stickySidebar.html.twig' with {
+    sidebar_items: [
+      '<nav class="table-of-contents">
+        <h2 class="table-of-contents__title">IN THIS GUIDE</h2>
+        <ol class="table-of-contents__list">
+          <li class="table-of-contents__list-item">
+            <a href="#" class="table-of-contents__link">Guidance summary</a>
+          </li>
+          <li class="table-of-contents__list-item">
+            <a href="#" class="table-of-contents__link">Introduction</a>
+          </li>
+          <li class="table-of-contents__list-item">
+            <a href="#" class="table-of-contents__link">
+              Requirements and overview of cooking methods
+            </a>
+          </li>
+          <li class="table-of-contents__list-item">
+            <a href="#" class="table-of-contents__link">Sous vide cooking method</a>
+          </li>
+          <li class="table-of-contents__list-item">
+            <a href="#" class="table-of-contents__link">Sear and shave method</a>
+          </li>
+          <li class="table-of-contents__list-item">
+            <a href="#" class="table-of-contents__link">Source control method</a>
+          </li>
+        </ol>
+      </nav>',
+      '<nav class="table-of-contents">
+        <h2 class="table-of-contents__title">ON THIS PAGE</h2>
+        <ol class="table-of-contents__list">
+          <li class="table-of-contents__list-item">
+            <a href="#" class="table-of-contents__link">Intended audience</a>
+          </li>
+          <li class="table-of-contents__list-item">
+            <a href="#" class="table-of-contents__link">Purpose of the guidance</a>
+          </li>
+          <li class="table-of-contents__list-item">
+            <a href="#" class="table-of-contents__link">
+              Legal status of the guidance
+            </a>
+          </li>
+        </ol>
+      </nav>'
+    ],
+  } %}
+{% endblock %}
+{% block right %}
+  
+  {% include '@components/components/multipageguide/Pagination/pagination.html.twig' with {
+    previous: {
+      label: "Previous",
+      page_name: "1. Guidance summary"
+    },
+    next: {
+      label: "Next",
+      page_name: "3. Requirements and overview of cooking methods"
+    }
+  } %}
+  {% include '@components/components/article/PdfAndPrintButtons/pdfAndPrintButtons.html.twig' with {
+    multipage_guide: true,
+    pdf_link: '#',
+    pdf_name: 'A third of UK consumers are willing to try lab-grown meat and a quarter would try insects',
+    pdf_name: 'Kirsty’s Classic Beef Lasagne Alert',
+    view: 'View',
+    as: 'as',
+    pdf: 'PDF',
+    new_window: 'Opens in a new window',
+    print_this_page: 'Print this page',
+    view_entire_guide: 'View entire guide as PDF',
+    print_guide: 'Print guide',
+    multipage_guide_pdf_link: '#',
+    multipage_guide_print_link: '#',
+  } %}
+{% endblock %}
+{% block footer %}
+{% endblock %}

--- a/src/pages/multipageguide/multipageguide.stories.js
+++ b/src/pages/multipageguide/multipageguide.stories.js
@@ -1,0 +1,13 @@
+import multipageguide from './multipageguide.html.twig';
+
+export default {
+  title: 'Pages/Multipage Guide',
+  parameters: {
+    controls: { disabled: true },
+    layout: 'fullscreen',
+  },
+};
+
+export const MultipageGuide = () => {
+  return multipageguide();
+};


### PR DESCRIPTION
- Added a new multipage guide section to hold the pagination
- Added the new pagination component with an example of each different stage (1st page, last page, in between)
- Took the existing html structure and adapted it so it fits in the grid and uses our current font-size, spacing etc
- Added a new multipage guide page with the pagination in it as an example

Side note: I also changed the focus state of the links in the temporary message

## Checklist before opening a PR

Before opening a PR, please make sure:

- [x] your work is in a branch based on and synced with the develop branch.
- [x] your scss and twig files are imported in the javascript file. Without this, Webpack won't be able to compile them.
- [x] your newComponent is imported in the index.js file.
- [x] your folder hierarchy follows the proper structure.
- [x] your code follows the coding standards and naming conventions defined.
- [x] your code has been tested as AA accessibility compliant to the WCAG 2.1 AA standard.
- [x] your code has been tested in all the browsers listed in the GDS browser's list, including IE11.
- [x] your code has been tested in all the different screensizes defined.
