### PR TITLE
Fix margins for MessageBox components.

### DIFF
--- a/src/components/form/ErrorBox/errorBox.scss
+++ b/src/components/form/ErrorBox/errorBox.scss
@@ -1,10 +1,10 @@
 @import "src/lib.scss";
 
 .error-box {
-  margin: 2rem -0.75rem 0;
+  margin: 2rem -0.75rem 2rem;
 
   @media screen and (min-width: $fsa-md) {
-    margin: 2rem -1.25rem 0;
+    margin: 2rem -1.25rem 2rem;
   }
 
   &__container {

--- a/src/components/form/MessageBox/messageBox.scss
+++ b/src/components/form/MessageBox/messageBox.scss
@@ -2,7 +2,7 @@
 @import "src/components/general/ExternalLink/externalLink.scss";
 
 .message-box {
-  margin-top: 2rem;
+  margin: 2rem 0 2rem;
   &__container {
     border-radius: 0.25rem;
     box-shadow: 0 0.25rem 1rem 0 rgba(41, 41, 41, 0.15);


### PR DESCRIPTION
During development https://deeson.atlassian.net/jira/software/c/projects/FSAR/boards/450?modal=detail&selectedIssue=FSAR-100&assignee=61dbf9a00586a200699c1b62 story I'd detected some problems with margins for multiple success messages and for error box. There wasn't any space between that block and the following element. 