### PR TITLE
FSAR-330: Highlights on nav dropdown wrong on IE11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Add margin to author div in the quote block
 - Improve screen reader accessibility on the navigation menu
+- Add css-vars-ponyfill back in to fix scss imports on Storybook
+- Change 'initial' to 'transparent' so that hover states look correct on IE11
 
 ### Security
 - 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "css-vars-ponyfill": "^2.4.7",
+    "css-vars-ponyfill": "2.4.7",
     "element-closest-polyfill": "1.0.4",
     "object-fit-images": "^3.2.4",
     "postcss": "8.4.8",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
+    "css-vars-ponyfill": "^2.4.7",
     "element-closest-polyfill": "1.0.4",
     "object-fit-images": "^3.2.4",
     "postcss": "8.4.8",

--- a/src/components/general/Navigation/navigation.scss
+++ b/src/components/general/Navigation/navigation.scss
@@ -363,7 +363,7 @@ $nav-height: 3.438rem;
           padding: 0.5rem 0 0.5rem 1rem;
 
           &:hover {
-            background-color: initial;
+            background-color: transparent;
             cursor: pointer;
             color: var(--fsa__link-green);
             text-decoration: underline;

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import './base.scss';
 import 'url-polyfill';
 import objectFitImages from 'object-fit-images';
+import cssVars from 'css-vars-ponyfill';
 import 'element-closest-polyfill';
 
 /* General Components */
@@ -101,6 +102,13 @@ import breadcrumbJs from './components/general/Breadcrumb/breadcrumb';
 import pagination from './components/search/Pagination/pagination';
 import searchBar from './components/search/SearchBar/searchBar';
 import sortBy from './components/search/SortBy/sortBy';
+
+// Fixes css vars on legacy browsers (i.e. IE11) - this is required for Storybook
+cssVars({
+  silent: true,
+  preserveVars: false,
+  onlyLegacy: false,
+});
 
 // Fixes object-fit on legacy browsers
 objectFitImages();

--- a/yarn.lock
+++ b/yarn.lock
@@ -4022,7 +4022,7 @@ bail@^1.0.0:
   version "1.0.5"
   resolved "https://registry.npmjs.org/bail/-/bail-1.0.5.tgz"
 
-balanced-match@^1.0.0:
+balanced-match@^1.0.0, balanced-match@^1.0.2:
   version "1.0.2"
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz"
 
@@ -5123,6 +5123,14 @@ css-select@^4.1.3:
     domhandler "^4.2.0"
     domutils "^2.6.0"
     nth-check "^2.0.0"
+
+css-vars-ponyfill@^2.4.7:
+  version "2.4.7"
+  resolved "https://registry.yarnpkg.com/css-vars-ponyfill/-/css-vars-ponyfill-2.4.7.tgz#df6fb2928e5ff013eb67e968761f8ed3d440b1e3"
+  integrity sha512-KhG3AbiZrUpIvAQ9Oc/iBqCitmXg6MajFqNRQd9nHvlwOo8p54HTq5DFCIaAUwMGRyttJ+mBmZCRSHJpe6J9cg==
+  dependencies:
+    balanced-match "^1.0.2"
+    get-css-data "^2.0.2"
 
 css-what@^3.2.1:
   version "3.4.2"
@@ -6481,6 +6489,11 @@ gensync@^1.0.0-beta.1, gensync@^1.0.0-beta.2:
 get-caller-file@^2.0.1:
   version "2.0.5"
   resolved "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz"
+
+get-css-data@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/get-css-data/-/get-css-data-2.0.2.tgz#5a24784f155944021b6f3fff304c15bcfcebdb9e"
+  integrity sha512-pYqg80/7u/MdBrrAQj2OIoZ08TxEnvCHyU5WFnPxxS/D0S8OpUTkqGFRzn8bO38DmtCuYBpR9VMCen78BL4jiQ==
 
 get-intrinsic@^1.0.2, get-intrinsic@^1.1.0, get-intrinsic@^1.1.1:
   version "1.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5124,7 +5124,7 @@ css-select@^4.1.3:
     domutils "^2.6.0"
     nth-check "^2.0.0"
 
-css-vars-ponyfill@^2.4.7:
+css-vars-ponyfill@2.4.7:
   version "2.4.7"
   resolved "https://registry.yarnpkg.com/css-vars-ponyfill/-/css-vars-ponyfill-2.4.7.tgz#df6fb2928e5ff013eb67e968761f8ed3d440b1e3"
   integrity sha512-KhG3AbiZrUpIvAQ9Oc/iBqCitmXg6MajFqNRQd9nHvlwOo8p54HTq5DFCIaAUwMGRyttJ+mBmZCRSHJpe6J9cg==


### PR DESCRIPTION
- Add css-vars-ponyfill back in to fix scss imports on Storybook
- Change 'initial' to 'transparent' so that hover states look correct on IE11

Please provide a thorough description of your component and its usage with screenshots.

## Checklist before opening a PR

Before opening a PR, please make sure:

- [ ] your work is in a branch based on and synced with the develop branch.
- [ ] your scss and twig files are imported in the javascript file. Without this, Webpack won't be able to compile them.
- [ ] your newComponent is imported in the index.js file.
- [ ] your folder hierarchy follows the proper structure.
- [ ] your code follows the coding standards and naming conventions defined.
- [ ] your code has been tested as AA accessibility compliant to the WCAG 2.1 AA standard.
- [ ] your code has been tested in all the browsers listed in the GDS browser's list, including IE11.
- [ ] your code has been tested in all the different screensizes defined.
- [ ] you have run the `yarn lint` command and fixed any linting errors.
- [ ] you have updated the CHANGELOG.md file with your changes.
