### PR TITLE
[FHTML-22] Add missing border top to the component.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,12 +27,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Upcoming release] - 1971-11-03
 
-
 ### Added
-- 
+- Polyfill for download attribute in IE11
 
 ### Changed
--
+- Add download option to button component
 
 ### Deprecated
 - 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,28 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -
 
 ### Security
--
-
-
-## [Upcoming release template] - 1971-11-03
-
-### Added
-- Polyfill for download attribute in IE11
-
-### Changed
-- Add download option to button component
-
-### Deprecated
-- 
-
-### Removed
-- 
-
-### Fixed
--
-
-### Security
--
 
 
 ## [Upcoming release] - 1971-11-03
@@ -72,8 +50,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.0.71] - 2022-03*18 (Revision log component)
 
 ### Added
-- Add new revision log component
 - Add revision log update to article hero component
+- Add new revision log component
 
 
 ## [0.0.70] - 2022-03-17 (Footnotes updated and fixes)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 
+## [Upcoming release] - 1971-11-03
+
+
+### Added
+- 
+
+### Changed
+-
+
+### Deprecated
+- 
+
+### Removed
+- 
+
+### Fixed
+- Revision log component add missing border
+
+### Security
+- 
+
+
 ## [0.0.71] - 2022-03*18 (Revision log component)
 
 ### Added

--- a/src/components/article/RevisionLogBottom/revisionLogBottom.scss
+++ b/src/components/article/RevisionLogBottom/revisionLogBottom.scss
@@ -30,7 +30,6 @@
     display: none;
     background: var(--fsa-primary_white);
     border: 0;
-    text-decoration: underline;
     font-size: 1rem;
     cursor: pointer;
     @include link;

--- a/src/components/article/RevisionLogBottom/revisionLogBottom.scss
+++ b/src/components/article/RevisionLogBottom/revisionLogBottom.scss
@@ -4,6 +4,7 @@
   padding-top: 2rem;
   margin-top: 3rem;
   border-top: solid 1px var(--fsa__grey-hover);
+
   &__control {
     display: flex;
     justify-content: space-between;
@@ -32,6 +33,7 @@
     border: 0;
     font-size: 1rem;
     cursor: pointer;
+
     @include link;
   }
 

--- a/src/components/article/RevisionLogBottom/revisionLogBottom.scss
+++ b/src/components/article/RevisionLogBottom/revisionLogBottom.scss
@@ -1,6 +1,9 @@
 @import "src/lib.scss";
 
 .revision-log {
+  padding-top: 2rem;
+  margin-top: 3rem;
+  border-top: solid 1px var(--fsa__grey-hover);
   &__control {
     display: flex;
     justify-content: space-between;
@@ -30,7 +33,7 @@
     text-decoration: underline;
     font-size: 1rem;
     cursor: pointer;
-    color: var(--fsa-primary_dark-green);
+    @include link;
   }
 
   &__toggle-button-show {


### PR DESCRIPTION
This is a fix to add a missing border to the revision log component.

![image](https://user-images.githubusercontent.com/2771242/159247187-031c3269-cca0-4d9f-a7d5-3abe15d286e9.png)

## Checklist before opening a PR

Before opening a PR, please make sure:

- [x] your work is in a branch based on and synced with the develop branch.
- [x] your scss and twig files are imported in the javascript file. Without this, Webpack won't be able to compile them.
- [x] your newComponent is imported in the index.js file.
- [x] your folder hierarchy follows the proper structure.
- [x] your code follows the coding standards and naming conventions defined.
- [x] your code has been tested as AA accessibility compliant to the WCAG 2.1 AA standard.
- [x] your code has been tested in all the browsers listed in the GDS browser's list, including IE11.
- [x] your code has been tested in all the different screensizes defined.
- [x] you have run the `yarn lint` command and fixed any linting errors.
- [x] you have updated the CHANGELOG.md file with your changes.
