### PR TITLE
[HACCP-62] Inline link on related content standard FSA styling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -
 
 
+## [Upcoming] - 1971-11-03
+
+### Added
+-
+
+### Changed
+- Related content - inline links within items have the correct link style.
+
+### Deprecated
+-
+
+### Removed
+-
+
+### Fixed
+-
+
+### Security
+-
+
+
 ## [0.0.86] - 2022-04-05 (Accessibility fix and improvement)
 
 ### Changed

--- a/src/components/article/RelatedContent/relatedContent.html.twig
+++ b/src/components/article/RelatedContent/relatedContent.html.twig
@@ -5,6 +5,9 @@
       {% if text is not empty %}
         <p class="related-content__main-text">{{ text }}</p>
       {% endif %}
+      {% if markup is not empty %}
+        <div class="related-content__main-text">{{ markup }}</div>
+      {% endif %}
     </div>
   </div>
   <div class="related-content__grid-container">

--- a/src/components/article/RelatedContent/relatedContent.scss
+++ b/src/components/article/RelatedContent/relatedContent.scss
@@ -110,10 +110,10 @@
   }
 
   &__card_no_link {
-    a{
+    a {
       @include link;
-
     }
+
     &::after {
       content: "";
       background-image: none;

--- a/src/components/article/RelatedContent/relatedContent.scss
+++ b/src/components/article/RelatedContent/relatedContent.scss
@@ -110,6 +110,10 @@
   }
 
   &__card_no_link {
+    a{
+      @include link;
+
+    }
     &::after {
       content: "";
       background-image: none;

--- a/src/components/article/RelatedContent/relatedContent.stories.js
+++ b/src/components/article/RelatedContent/relatedContent.stories.js
@@ -73,7 +73,7 @@ RelatedContentWithNoLink.args = {
 export const RelatedContentWithMarkup = Template.bind({});
 RelatedContentWithMarkup.args = {
   title: 'Related content',
-  text: 'The MyHACCP Tool will be able to produce a food safety management system that shows how your business identifies and controls any hazards that may occur in the food you manufacture. You will find a range of resources to assist you with completing the tool and with understanding implementation of HACCP principles more generally in the Help section.',
+  markup: '<p>The MyHACCP Tool will be able to produce a food safety management system that shows how your business identifies and controls any hazards that may occur in the food you manufacture. You will find a range of resources to assist you with completing the tool and with understanding implementation of HACCP principles more generally in the Help section.</p>',
   cards: [
     {
       title: 'Who is this site for?',
@@ -90,8 +90,8 @@ RelatedContentWithMarkup.args = {
     {
       title: 'What next?',
       markup:
-        '<ol><li>Sign up for an account.</li><li>Start the MyHACCP process at the beginning or at any point – you can come back and finish it at any time</li><li>Complete the MyHACCP process  - you can preview what the output will look like at any stage</li><li>Print or download the completed food safety management system documents for your records</li></ol>',
-      link: '#',
+        '<ol><li><a href="">Sign up for an account.</a></li><li>Start the MyHACCP process at the beginning or at any point – you can come back and finish it at any time</li><li>Complete the MyHACCP process  - you can preview what the output will look like at any stage</li><li>Print or download the completed food safety management system documents for your records</li></ol>',
+      link: '',
     },
   ],
 };

--- a/src/components/article/RelatedContent/relatedContent.stories.js
+++ b/src/components/article/RelatedContent/relatedContent.stories.js
@@ -73,7 +73,8 @@ RelatedContentWithNoLink.args = {
 export const RelatedContentWithMarkup = Template.bind({});
 RelatedContentWithMarkup.args = {
   title: 'Related content',
-  markup: '<p>The MyHACCP Tool will be able to produce a food safety management system that shows how your business identifies and controls any hazards that may occur in the food you manufacture. You will find a range of resources to assist you with completing the tool and with understanding implementation of HACCP principles more generally in the Help section.</p>',
+  markup:
+    '<p>The MyHACCP Tool will be able to produce a food safety management system that shows how your business identifies and controls any hazards that may occur in the food you manufacture. You will find a range of resources to assist you with completing the tool and with understanding implementation of HACCP principles more generally in the Help section.</p>',
   cards: [
     {
       title: 'Who is this site for?',


### PR DESCRIPTION
It was noticed that when the related content items do not have the main link added and a link is added inline, they do not have the correct FSA styling.
This PR fixes that.

![Screenshot 2022-04-06 at 14-12-22 Storybook](https://user-images.githubusercontent.com/2771242/161984374-02c2bec8-e7e0-47ac-a9ba-360bc42227b2.png)

Before opening a PR, please make sure:

- [x] your work is in a branch based on and synced with the develop branch.
- [x] your scss and twig files are imported in the javascript file. Without this, Webpack won't be able to compile them.
- [x] your newComponent is imported in the index.js file.
- [x] your folder hierarchy follows the proper structure.
- [x] your code follows the coding standards and naming conventions defined.
- [x] your code has been tested as AA accessibility compliant to the WCAG 2.1 AA standard.
- [x] your code has been tested in all the browsers listed in the GDS browser's list, including IE11.
- [x] your code has been tested in all the different screensizes defined.
- [x] you have run the `yarn lint` command and fixed any linting errors.
- [x] you have updated the CHANGELOG.md file with your changes.
