### PR TITLE
make the "display contents" rule apply for any tag in <li>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - If there's a `<p>` tag in a list, ignore it and display its contents
+- ignore any direct child tag (except a) in a list and display its contents
 
 ### Security
 -

--- a/src/lib.scss
+++ b/src/lib.scss
@@ -567,7 +567,7 @@ $mobileGutter: 1rem;
       margin-left: -1.5rem;
     }
 
-    p {
+    * {
       display: contents;
     }
   }

--- a/src/lib.scss
+++ b/src/lib.scss
@@ -567,7 +567,7 @@ $mobileGutter: 1rem;
       margin-left: -1.5rem;
     }
 
-    * {
+    > *:not(a) {
       display: contents;
     }
   }


### PR DESCRIPTION
I've adapted your rule to take into account any direct child from an li (except the a tag as we want to display the links). On some occasions, we also have an `<aside>` tag 🤷🏻‍♀️ 

## Checklist before opening a PR

Before opening a PR, please make sure:

- [ ] your work is in a branch based on and synced with the develop branch.
- [ ] your scss and twig files are imported in the javascript file. Without this, Webpack won't be able to compile them.
- [ ] your newComponent is imported in the index.js file.
- [ ] your folder hierarchy follows the proper structure.
- [ ] your code follows the coding standards and naming conventions defined.
- [ ] your code has been tested as AA accessibility compliant to the WCAG 2.1 AA standard.
- [ ] your code has been tested in all the browsers listed in the GDS browser's list, including IE11.
- [ ] your code has been tested in all the different screensizes defined.
- [ ] you have run the `yarn lint` command and fixed any linting errors.
- [ ] you have updated the CHANGELOG.md file with your changes.
