### PR TITLE
[FSAR-379] Fixing Sidebar overflow when reaching bottom of page and when reaching top of page when page already scrolled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -
 
 
-## [0.1.8] -  2022-05-16 (Updating input and text fields to have char limit and disabled/readonly features)
+## [Upcoming release] - 1971-11-03
 
+### Added
+-
+
+### Changed
+-
+
+### Deprecated
+-
+
+### Removed
+-
+
+### Fixed
+- Fixing Sidebar overflow when reaching bottom of page and when reaching top of page when page already scrolled
+
+### Security
+-
+
+
+## [0.1.8] -  2022-05-16 (Updating input and text fields to have char limit and disabled/readonly features)
 
 ### Changed
 - Update textarea and input form field types to add character limits

--- a/src/components/article/StickySidebar/stickySidebar.html.twig
+++ b/src/components/article/StickySidebar/stickySidebar.html.twig
@@ -1,7 +1,9 @@
-<div class="sticky-sidebar">
-  {% for item in sidebar_items %}
-    <div class="sticky-sidebar__content-item">
-      {{ item }}
-    </div>
-  {% endfor %}
+<div class="sticky-sidebar__wrapper">
+  <div class="sticky-sidebar">
+    {% for item in sidebar_items %}
+      <div class="sticky-sidebar__content-item">
+        {{ item }}
+      </div>
+    {% endfor %}
+  </div>
 </div>

--- a/src/components/article/StickySidebar/stickySidebar.scss
+++ b/src/components/article/StickySidebar/stickySidebar.scss
@@ -4,7 +4,6 @@
   margin-bottom: 2rem;
 
   @media screen and (min-width: $fsa-lg) {
-    height: 100%;
     margin-top: 0;
   }
 
@@ -18,9 +17,9 @@
 
   &--bottom {
     @media screen and (min-width: $fsa-lg) {
-      position: relative;
+      position: absolute;
       display: flex;
-      align-items: flex-end;
+      flex-direction: column;
       bottom: 0;
     }
   }
@@ -31,5 +30,10 @@
     &:first-child {
       margin-top: 0;
     }
+  }
+
+  &__wrapper {
+    position: relative;
+    height: 100%;
   }
 }


### PR DESCRIPTION
I noticed while testing FSAR-374 that the sidebar was overflowing over the Related Content section so I initially wanted to fix this bug. Then I saw the overflow happens also at the top when the viewport starts in the middle of the page.

I adapted the code in an attempt to handle any cases.

Tested with Related content section https://fsa.localhost/business-guidance/allergen-guidance-for-food-businesses and without https://fsa.localhost/research/food-allergy-and-intolerance-research/rapid-risk-assessment-on-the-risk-of-allergic-reactions-in-uk-consumers-if-sunflower-oil-is-substituted-with-refined-rapeseed or https://fsa.localhost/research/research-projects/a-survey-of-salmonella-escherichia-coli-e-coli-and-antimicrobial-resistance-in-frozen-part-cooked-breaded-or-battered-poultry

## Checklist before opening a PR

Before opening a PR, please make sure:

- [ ] your work is in a branch based on and synced with the develop branch.
- [ ] your scss and twig files are imported in the javascript file. Without this, Webpack won't be able to compile them.
- [ ] your newComponent is imported in the index.js file.
- [ ] your folder hierarchy follows the proper structure.
- [ ] your code follows the coding standards and naming conventions defined.
- [ ] your code has been tested as AA accessibility compliant to the WCAG 2.1 AA standard.
- [ ] your code has been tested in all the browsers listed in the GDS browser's list, including IE11.
- [ ] your code has been tested in all the different screensizes defined.
- [ ] you have run the `yarn lint` command and fixed any linting errors.
- [ ] you have updated the CHANGELOG.md file with your changes.
